### PR TITLE
Bugfix multiple non unique fields

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,4 +1,4 @@
-use crate::multi_index::MultiIndexOrderMap;
+use crate::multi_index_order::MultiIndexOrderMap;
 use multi_index_map::MultiIndexMap;
 
 #[derive(MultiIndexMap, Debug, Clone)]

--- a/tests/hashed_non_unique.rs
+++ b/tests/hashed_non_unique.rs
@@ -1,5 +1,5 @@
-use multi_index::MultiIndexTestElementMap;
 use multi_index_map::MultiIndexMap;
+use multi_index_test_element::MultiIndexTestElementMap;
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug)]
 struct TestNonPrimitiveType(u64);

--- a/tests/hashed_unique.rs
+++ b/tests/hashed_unique.rs
@@ -1,5 +1,5 @@
-use multi_index::MultiIndexTestElementMap;
 use multi_index_map::MultiIndexMap;
+use multi_index_test_element::MultiIndexTestElementMap;
 
 #[derive(Hash, PartialEq, Eq, Clone)]
 struct TestNonPrimitiveType(u64);

--- a/tests/mixed_non_unique.rs
+++ b/tests/mixed_non_unique.rs
@@ -1,0 +1,31 @@
+use multi_index::MultiIndexClientSubscriptionMap;
+use multi_index_map::MultiIndexMap;
+
+#[derive(MultiIndexMap, Clone, Debug)]
+struct ClientSubscription {
+    #[multi_index(ordered_non_unique)]
+    field1: u32,
+    #[multi_index(ordered_non_unique)]
+    field2: u64,
+}
+
+#[test]
+fn test_two_ordered_fields() {
+    let mut map = MultiIndexClientSubscriptionMap::default();
+
+    map.insert(ClientSubscription {
+        field1: 1,
+        field2: 999,
+    });
+    map.insert(ClientSubscription {
+        field1: 2,
+        field2: 999,
+    });
+
+    let a = map.remove_by_field1(&1);
+
+    let b = map.get_by_field2(&999);
+
+    assert_eq!(a.len(), 1);
+    assert_eq!(b.len(), 1);
+}

--- a/tests/mixed_non_unique.rs
+++ b/tests/mixed_non_unique.rs
@@ -1,8 +1,10 @@
-use multi_index::MultiIndexClientSubscriptionMap;
 use multi_index_map::MultiIndexMap;
+use multi_index_multiple_hashed_non_unique_struct::MultiIndexMultipleHashedNonUniqueStructMap;
+use multi_index_multiple_ordered_non_unique_struct::MultiIndexMultipleOrderedNonUniqueStructMap;
+use multi_index_ordered_non_unique_and_hashed_non_unique_struct::MultiIndexOrderedNonUniqueAndHashedNonUniqueStructMap;
 
-#[derive(MultiIndexMap, Clone, Debug)]
-struct ClientSubscription {
+#[derive(MultiIndexMap, Clone)]
+struct MultipleOrderedNonUniqueStruct {
     #[multi_index(ordered_non_unique)]
     field1: u32,
     #[multi_index(ordered_non_unique)]
@@ -10,22 +12,143 @@ struct ClientSubscription {
 }
 
 #[test]
-fn test_two_ordered_fields() {
-    let mut map = MultiIndexClientSubscriptionMap::default();
+fn test_remove_ordered_non_unique_field1_get_ordered_non_unique_field2() {
+    let mut map = MultiIndexMultipleOrderedNonUniqueStructMap::default();
 
-    map.insert(ClientSubscription {
+    map.insert(MultipleOrderedNonUniqueStruct {
         field1: 1,
         field2: 999,
     });
-    map.insert(ClientSubscription {
+    map.insert(MultipleOrderedNonUniqueStruct {
         field1: 2,
         field2: 999,
     });
 
     let a = map.remove_by_field1(&1);
-
     let b = map.get_by_field2(&999);
 
     assert_eq!(a.len(), 1);
     assert_eq!(b.len(), 1);
+}
+
+#[test]
+fn test_remove_ordered_non_unique_field2_get_ordered_non_unique_field1() {
+    let mut map = MultiIndexMultipleOrderedNonUniqueStructMap::default();
+
+    map.insert(MultipleOrderedNonUniqueStruct {
+        field1: 1,
+        field2: 999,
+    });
+    map.insert(MultipleOrderedNonUniqueStruct {
+        field1: 2,
+        field2: 999,
+    });
+
+    let a = map.remove_by_field2(&999);
+    let b = map.get_by_field1(&1);
+    let c = map.get_by_field1(&2);
+
+    assert_eq!(a.len(), 2);
+    assert_eq!(b.len(), 0);
+    assert_eq!(c.len(), 0);
+}
+
+#[derive(MultiIndexMap, Clone)]
+struct OrderedNonUniqueAndHashedNonUniqueStruct {
+    #[multi_index(hashed_non_unique)]
+    field1: u32,
+    #[multi_index(ordered_non_unique)]
+    field2: u64,
+}
+
+#[test]
+fn test_remove_hashed_non_unique_field1_get_ordered_non_unique_field2() {
+    let mut map = MultiIndexOrderedNonUniqueAndHashedNonUniqueStructMap::default();
+
+    map.insert(OrderedNonUniqueAndHashedNonUniqueStruct {
+        field1: 1,
+        field2: 999,
+    });
+    map.insert(OrderedNonUniqueAndHashedNonUniqueStruct {
+        field1: 2,
+        field2: 999,
+    });
+
+    let a = map.remove_by_field1(&1);
+    let b = map.get_by_field2(&999);
+
+    assert_eq!(a.len(), 1);
+    assert_eq!(b.len(), 1);
+}
+
+#[test]
+fn test_remove_ordered_non_unique_field2_get_hashed_non_unique_field1() {
+    let mut map = MultiIndexOrderedNonUniqueAndHashedNonUniqueStructMap::default();
+
+    map.insert(OrderedNonUniqueAndHashedNonUniqueStruct {
+        field1: 1,
+        field2: 999,
+    });
+    map.insert(OrderedNonUniqueAndHashedNonUniqueStruct {
+        field1: 2,
+        field2: 999,
+    });
+
+    let a = map.remove_by_field2(&999);
+    let b = map.get_by_field1(&1);
+    let c = map.get_by_field1(&2);
+
+    assert_eq!(a.len(), 2);
+    assert_eq!(b.len(), 0);
+    assert_eq!(c.len(), 0);
+}
+
+#[derive(MultiIndexMap, Clone)]
+struct MultipleHashedNonUniqueStruct {
+    #[multi_index(hashed_non_unique)]
+    field1: u32,
+    #[multi_index(ordered_non_unique)]
+    field2: u64,
+}
+
+#[test]
+fn test_remove_hashed_non_unique_field1_get_hashed_non_unique_field2() {
+    let mut map = MultiIndexMultipleHashedNonUniqueStructMap::default();
+
+    map.insert(MultipleHashedNonUniqueStruct {
+        field1: 1,
+        field2: 999,
+    });
+    map.insert(MultipleHashedNonUniqueStruct {
+        field1: 2,
+        field2: 999,
+    });
+
+    let a = map.remove_by_field1(&1);
+    let b = map.get_by_field2(&999);
+
+    assert_eq!(a.len(), 1);
+    assert_eq!(b.len(), 1);
+}
+
+#[test]
+fn test_remove_hashed_non_unique_field2_get_hashed_non_unique_field1() {
+    let mut map = MultiIndexMultipleHashedNonUniqueStructMap::default();
+
+    map.insert(MultipleHashedNonUniqueStruct {
+        field1: 1,
+        field2: 999,
+    });
+    map.insert(MultipleHashedNonUniqueStruct {
+        field1: 2,
+        field2: 999,
+    });
+
+    let a = map.remove_by_field2(&999);
+    let b = map.get_by_field1(&1);
+    let c = map.get_by_field1(&2);
+
+    assert_eq!(a.len(), 2);
+    assert_eq!(b.len(), 0);
+    assert_eq!(c.len(), 0);
 }

--- a/tests/ordered_non_unique.rs
+++ b/tests/ordered_non_unique.rs
@@ -1,5 +1,5 @@
-use multi_index::MultiIndexTestElementMap;
 use multi_index_map::MultiIndexMap;
+use multi_index_test_element::MultiIndexTestElementMap;
 
 #[derive(Hash, PartialEq, Eq, Clone, Debug, PartialOrd, Ord)]
 struct TestNonPrimitiveType(u64);

--- a/tests/ordered_unique.rs
+++ b/tests/ordered_unique.rs
@@ -1,5 +1,5 @@
-use multi_index::MultiIndexTestElementMap;
 use multi_index_map::MultiIndexMap;
+use multi_index_test_element::MultiIndexTestElementMap;
 
 #[derive(Hash, PartialEq, Eq, Clone, PartialOrd, Ord)]
 struct TestNonPrimitiveType(u64);


### PR DESCRIPTION
An issue existed in v0.3.0 whereby removing an element from any non-unique index while another non-unique index is present, would break the internal invariants and cause any other elements to become inaccessible through the other non-unique index.

Also since v0.2.0 only a single MultiIndexMap could be defined per namespace due to conflicting `mod multi_index {}` statements. Changed to `mod multi_index_element_name {}` to avoid clashes. This will require code changes for downstream users, so is a breaking change.