### PR TITLE
More usefully located error messages

### DIFF
--- a/multi_index_map_derive/src/generators.rs
+++ b/multi_index_map_derive/src/generators.rs
@@ -4,8 +4,6 @@ use ::syn::{Field, Visibility};
 
 use crate::index_attributes::{Ordering, Uniqueness};
 
-// const MISSING_ATTRIBUTE: &str = "Missing #[multi_index(...)] attribute";
-
 // For each indexed field generate a TokenStream representing the lookup table for that field
 // Each lookup table maps it's index to a position in the backing storage,
 // or multiple positions in the backing storage in the non-unique indexes.

--- a/multi_index_map_derive/src/index_attributes.rs
+++ b/multi_index_map_derive/src/index_attributes.rs
@@ -1,4 +1,6 @@
 use ::syn::Field;
+use proc_macro_error::emit_error;
+use syn::spanned::Spanned;
 
 // Represents whether the index is Ordered or Hashed, ie. whether we use a BTreeMap or a FxHashMap
 //   as the lookup table.
@@ -39,6 +41,7 @@ pub(crate) fn get_index_kind(f: &Field) -> Option<(Ordering, Uniqueness)> {
             } else if nested_path.is_ident("ordered_non_unique") {
                 return Some((Ordering::Ordered, Uniqueness::NonUnique));
             } else {
+                emit_error!(nested_path.span(), "Invalid multi_index attribute, should be one of [hashed_unique, ordered_unique, hashed_non_unique, ordered_non_unique]");
                 return None;
             }
         }

--- a/multi_index_map_derive/src/lib.rs
+++ b/multi_index_map_derive/src/lib.rs
@@ -32,7 +32,10 @@ pub fn multi_index_map(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
     let fields_to_index = named_fields
         .named
         .iter()
-        .filter(|f| f.attrs.iter().any(|attr| attr.path.is_ident("multi_index")))
+        .filter_map(|f| {
+            let (ordering, uniqueness) = index_attributes::get_index_kind(f)?;
+            Some((f, ordering, uniqueness))
+        })
         .collect::<Vec<_>>();
 
     let lookup_table_fields = generators::generate_lookup_tables(&fields_to_index);


### PR DESCRIPTION
Plus optimise work done at compile time, so we only lookup the ordering and uniqueness values once for each field.