### PR TITLE
14 macro should not require clone by default

### DIFF
--- a/multi_index_map_derive/src/generators.rs
+++ b/multi_index_map_derive/src/generators.rs
@@ -157,7 +157,7 @@ pub(crate) fn generate_removes(
     fields
         .iter()
         .map(|(f, _ordering, uniqueness)| {
-            let field_name = f.ident.as_ref().unwrap();
+            let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
             let field_name_string = field_name.to_string();
             let index_name = format_ident!("_{field_name}_index");
             let error_msg = format!(
@@ -272,7 +272,7 @@ pub(crate) fn generate_clears(
     fields: &[(Field, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
     fields.iter().map(|(f, _ordering, _uniqueness)| {
-        let field_name = f.ident.as_ref().unwrap();
+        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
         let index_name = format_ident!("_{field_name}_index");
 
         quote! {
@@ -305,7 +305,7 @@ pub(crate) fn generate_accessors<'a>(
     let unindexed_idents = unindexed_fields
         .iter()
         .map(|f| {
-            let ident = &f.ident;
+            let ident = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
             quote! {
                 #ident
             }
@@ -584,7 +584,7 @@ pub(crate) fn generate_iterators<'a>(
     element_name: &'a proc_macro2::Ident,
 ) -> impl Iterator<Item = proc_macro2::TokenStream> + 'a {
     fields.iter().map(move |(f, ordering, uniqueness)| {
-        let field_name = f.ident.as_ref().unwrap();
+        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
         let field_vis = &f.vis;
         let field_name_string = field_name.to_string();
         let error_msg = format!(

--- a/multi_index_map_derive/src/generators.rs
+++ b/multi_index_map_derive/src/generators.rs
@@ -1,37 +1,44 @@
-use ::convert_case::Casing;
 use ::quote::{format_ident, quote};
 use ::syn::{Field, Visibility};
+use proc_macro2::Ident;
 use proc_macro_error::OptionExt;
 
 use crate::index_attributes::{Ordering, Uniqueness};
 
-const EXPECT_NAMED_FIELDS: &str = "Internal logic broken, all fields should have named identifiers";
+pub(crate) struct Idents {
+    pub(crate) index: Ident,
+    pub(crate) orig: Ident,
+    pub(crate) iter: Ident,
+}
+
+pub(crate) const EXPECT_NAMED_FIELDS: &str =
+    "Internal logic broken, all fields should have named identifiers";
 
 // For each indexed field generate a TokenStream representing the lookup table for that field
 // Each lookup table maps it's index to a position in the backing storage,
 // or multiple positions in the backing storage in the non-unique indexes.
 pub(crate) fn generate_lookup_tables(
-    fields: &[(Field, Ordering, Uniqueness)],
+    fields: &[(Field, Idents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
-    fields.iter().map(|(f, ordering, uniqueness)| {
-        let index_name = format_ident!("_{}_index", f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS));
+    fields.iter().map(|(f, idents, ordering, uniqueness)| {
         let ty = &f.ty;
+        let index_ident = &idents.index;
 
         match uniqueness {
             Uniqueness::Unique => match ordering {
                 Ordering::Hashed => quote! {
-                    #index_name: ::multi_index_map::rustc_hash::FxHashMap<#ty, usize>,
+                    #index_ident: ::multi_index_map::rustc_hash::FxHashMap<#ty, usize>,
                 },
                 Ordering::Ordered => quote! {
-                    #index_name: ::std::collections::BTreeMap<#ty, usize>,
+                    #index_ident: ::std::collections::BTreeMap<#ty, usize>,
                 },
             },
             Uniqueness::NonUnique => match ordering {
                 Ordering::Hashed => quote! {
-                    #index_name: ::multi_index_map::rustc_hash::FxHashMap<#ty, ::std::collections::BTreeSet<usize>>,
+                    #index_ident: ::multi_index_map::rustc_hash::FxHashMap<#ty, ::std::collections::BTreeSet<usize>>,
                 },
                 Ordering::Ordered => quote! {
-                    #index_name: ::std::collections::BTreeMap<#ty, ::std::collections::BTreeSet<usize>>,
+                    #index_ident: ::std::collections::BTreeMap<#ty, ::std::collections::BTreeSet<usize>>,
                 },
             },
         }
@@ -43,20 +50,16 @@ pub(crate) fn generate_lookup_tables(
 // If lookup table data structures support `with_capacity`, change `default()` and `new()` calls to
 //   `with_capacity(n)`
 pub(crate) fn generate_lookup_table_init(
-    fields: &[(Field, Ordering, Uniqueness)],
+    fields: &[(Field, Idents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
-    fields.iter().map(|(f, ordering, _uniqueness)| {
-        let index_name = format_ident!(
-            "_{}_index",
-            f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS)
-        );
-
+    fields.iter().map(|(_f, idents, ordering, _uniqueness)| {
+        let index_ident = &idents.index;
         match ordering {
             Ordering::Hashed => quote! {
-                #index_name: ::multi_index_map::rustc_hash::FxHashMap::default(),
+                #index_ident: ::multi_index_map::rustc_hash::FxHashMap::default(),
             },
             Ordering::Ordered => quote! {
-                #index_name: ::std::collections::BTreeMap::new(),
+                #index_ident: ::std::collections::BTreeMap::new(),
             },
         }
     })
@@ -67,17 +70,14 @@ pub(crate) fn generate_lookup_table_init(
 // Currently `BTreeMap::extend_reserve()` is nightly-only and uses the trait default implementation, which does nothing.
 // Once this is implemented and stabilized, we will use it here to reserve capacity.
 pub(crate) fn generate_lookup_table_reserve(
-    fields: &[(Field, Ordering, Uniqueness)],
+    fields: &[(Field, Idents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
-    fields.iter().map(|(f, ordering, _uniqueness)| {
-        let index_name = format_ident!(
-            "_{}_index",
-            f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS)
-        );
+    fields.iter().map(|(_f, idents, ordering, _uniqueness)| {
+        let index_ident = &idents.index;
 
         match ordering {
             Ordering::Hashed => quote! {
-                self.#index_name.reserve(additional);
+                self.#index_ident.reserve(additional);
             },
             Ordering::Ordered => quote! {},
         }
@@ -89,17 +89,14 @@ pub(crate) fn generate_lookup_table_reserve(
 // For consistency, HashMaps are shrunk to the capacity of the backing storage
 // `BTreeMap` does not support shrinking.
 pub(crate) fn generate_lookup_table_shrink(
-    fields: &[(Field, Ordering, Uniqueness)],
+    fields: &[(Field, Idents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
-    fields.iter().map(|(f, ordering, _uniqueness)| {
-        let index_name = format_ident!(
-            "_{}_index",
-            f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS)
-        );
+    fields.iter().map(|(_f, idents, ordering, _uniqueness)| {
+        let index_ident = &idents.index;
 
         match ordering {
             Ordering::Hashed => quote! {
-                self.#index_name.shrink_to_fit();
+                self.#index_ident.shrink_to_fit();
             },
             Ordering::Ordered => quote! {},
         }
@@ -112,25 +109,25 @@ pub(crate) fn generate_lookup_table_shrink(
 //   whereas non-unique fields require inserting to the container of positions,
 //   creating a new container if necessary.
 pub(crate) fn generate_inserts(
-    fields: &[(Field, Ordering, Uniqueness)],
+    fields: &[(Field, Idents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
-    fields.iter().map(|(f, _ordering, uniqueness)| {
-        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
-        let field_name_string = field_name.to_string();
-        let index_name = format_ident!("_{field_name}_index");
+    fields.iter().map(|(f, idents, _ordering, uniqueness)| {
+        let field_ident = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
+        let field_ident_string = stringify!(field_ident);
+        let index_ident = &idents.index;
 
         match uniqueness {
             Uniqueness::Unique => quote! {
-                let orig_elem_idx = self.#index_name.insert(elem.#field_name.clone(), idx);
+                let orig_elem_idx = self.#index_ident.insert(elem.#field_ident.clone(), idx);
                 if orig_elem_idx.is_some() {
                     panic!(
                         "Unable to insert element, uniqueness constraint violated on field '{}'",
-                        #field_name_string
+                        #field_ident_string
                     );
                 }
             },
             Uniqueness::NonUnique => quote! {
-                self.#index_name.entry(elem.#field_name.clone())
+                self.#index_ident.entry(elem.#field_ident.clone())
                     .or_insert(::std::collections::BTreeSet::new())
                     .insert(idx);
             },
@@ -145,42 +142,42 @@ pub(crate) fn generate_inserts(
 // The index of the removed element in the backing storage before its removal is given as `idx`
 // Remove idx from the lookup table:
 //   - When the field is unique, check that the index is indeed idx,
-//     then delete the corresponding key (elem_orig.#field_name) from the field
+//     then delete the corresponding key (elem_orig.#field_ident) from the field
 //   - When the field is non-unique, get a reference to the container that
-//     contains all back storage indices under the same key (elem_orig.#field_name),
+//     contains all back storage indices under the same key (elem_orig.#field_ident),
 //     + If there are more than one indices in the container, remove idx from it
 //     + If there are exactly one index in the container, then the index has to be idx,
 //       remove the key from the lookup table
 pub(crate) fn generate_removes(
-    fields: &[(Field, Ordering, Uniqueness)],
+    fields: &[(Field, Idents, Ordering, Uniqueness)],
 ) -> Vec<::proc_macro2::TokenStream> {
     fields
         .iter()
-        .map(|(f, _ordering, uniqueness)| {
-            let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
-            let field_name_string = field_name.to_string();
-            let index_name = format_ident!("_{field_name}_index");
+        .map(|(f, idents, _ordering, uniqueness)| {
+            let field_ident = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
+            let field_ident_string = stringify!(field_ident);
             let error_msg = format!(
                 concat!(
                     "Internal invariants broken, ",
                     "unable to find element in index '{}' despite being present in another"
                 ),
-                field_name_string
+                field_ident_string
             );
+            let index_ident = &idents.index;
 
             match uniqueness {
                 Uniqueness::Unique => quote! {
-                    let _removed_elem = self.#index_name.remove(&elem_orig.#field_name);
+                    let _removed_elem = self.#index_ident.remove(&elem_orig.#field_ident);
                 },
                 Uniqueness::NonUnique => quote! {
-                    let key_to_remove = &elem_orig.#field_name;
-                    if let Some(elems) = self.#index_name.get_mut(key_to_remove) {
+                    let key_to_remove = &elem_orig.#field_ident;
+                    if let Some(elems) = self.#index_ident.get_mut(key_to_remove) {
                         if elems.len() > 1 {
                             if !elems.remove(&idx){
                                 panic!(#error_msg);
                             }
                         } else {
-                            self.#index_name.remove(key_to_remove);
+                            self.#index_ident.remove(key_to_remove);
                         }
                     }
 
@@ -193,13 +190,13 @@ pub(crate) fn generate_removes(
 // For each indexed field generate a TokenStream representing the clone the original value,
 //   so that we can compare after the modify is applied and adjust lookup tables as necessary
 pub(crate) fn generate_pre_modifies(
-    fields: &[(Field, Ordering, Uniqueness)],
+    fields: &[(Field, Idents, Ordering, Uniqueness)],
 ) -> Vec<::proc_macro2::TokenStream> {
     fields
         .iter()
-        .map(|(field, _, _)| {
+        .map(|(field, idents, _, _)| {
             let ident = field.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
-            let orig_ident = format_ident!("orig_{ident}");
+            let orig_ident = &idents.orig;
 
             quote! {
                 let #orig_ident = elem.#ident.clone();
@@ -211,55 +208,55 @@ pub(crate) fn generate_pre_modifies(
 // For each indexed field generate a TokenStream representing the combined remove and insert from that
 //   field's lookup table.
 // Used in modifier. Run after an element is already modified in the backing storage.
-// The fields of the original element are stored in `orig_#field_name`
+// The fields of the original element are stored in `orig_#field_ident`
 // The element after change is stored in reference `elem` (inside the backing storage).
 // The index of `elem` in the backing storage is `idx`
-// For each field, only make changes if `elem.#field_name` and `orig_#field_name` are not equal
+// For each field, only make changes if `elem.#field_ident` and `orig_#field_ident` are not equal
 //   - When the field is unique, remove the old key and insert idx under the new key
 //     (if new key already exists, panic!)
 //   - When the field is non-unique, remove idx from the container associated with the old key
 //     + if the container is empty after removal, remove the old key, and insert idx to the new key
 //       (create a new container if necessary)
 pub(crate) fn generate_post_modifies(
-    fields: &[(Field, Ordering, Uniqueness)],
+    fields: &[(Field, Idents, Ordering, Uniqueness)],
 ) -> Vec<::proc_macro2::TokenStream> {
-    fields.iter().map(|(f, _ordering, uniqueness)| {
-        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
-        let field_name_string = field_name.to_string();
-        let orig_ident = format_ident!("orig_{field_name}");
-        let index_name = format_ident!("_{field_name}_index");
+    fields.iter().map(|(f, idents, _ordering, uniqueness)| {
+        let field_ident = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
+        let field_ident_string = stringify!(field_ident);
+        let orig_ident = &idents.orig;
+        let index_ident = &idents.index;
         let error_msg = format!(
             concat!(
                 "Internal invariants broken, ",
                 "unable to find element in index '{}' despite being present in another"
             ),
-            field_name_string
+            field_ident_string
         );
 
         match uniqueness {
             Uniqueness::Unique => quote! {
-                if elem.#field_name != #orig_ident {
-                    let idx = self.#index_name.remove(&#orig_ident).expect(#error_msg);
-                    let orig_elem_idx = self.#index_name.insert(elem.#field_name.clone(), idx);
+                if elem.#field_ident != #orig_ident {
+                    let idx = self.#index_ident.remove(&#orig_ident).expect(#error_msg);
+                    let orig_elem_idx = self.#index_ident.insert(elem.#field_ident.clone(), idx);
                     if orig_elem_idx.is_some() {
                         panic!(
                             "Unable to insert element, uniqueness constraint violated on field '{}'",
-                            #field_name_string
+                            #field_ident_string
                         );
                     }
                 }
             },
             Uniqueness::NonUnique => quote! {
-                if elem.#field_name != #orig_ident {
-                    let idxs = self.#index_name.get_mut(&#orig_ident).expect(#error_msg);
+                if elem.#field_ident != #orig_ident {
+                    let idxs = self.#index_ident.get_mut(&#orig_ident).expect(#error_msg);
                     if idxs.len() > 1 {
                         if !(idxs.remove(&idx)) {
                             panic!(#error_msg);
                         }
                     } else {
-                        self.#index_name.remove(&#orig_ident);
+                        self.#index_ident.remove(&#orig_ident);
                     }
-                    self.#index_name.entry(elem.#field_name.clone())
+                    self.#index_ident.entry(elem.#field_ident.clone())
                         .or_insert(::std::collections::BTreeSet::new())
                         .insert(idx);
                 }
@@ -269,11 +266,10 @@ pub(crate) fn generate_post_modifies(
 }
 
 pub(crate) fn generate_clears(
-    fields: &[(Field, Ordering, Uniqueness)],
+    fields: &[(Field, Idents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
-    fields.iter().map(|(f, _ordering, _uniqueness)| {
-        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
-        let index_name = format_ident!("_{field_name}_index");
+    fields.iter().map(|(_f, idents, _ordering, _uniqueness)| {
+        let index_name = &idents.index;
 
         quote! {
             self.#index_name.clear();
@@ -284,49 +280,31 @@ pub(crate) fn generate_clears(
 // For each indexed field generate a TokenStream representing all the accessors
 //   for the underlying storage via that field's lookup table.
 pub(crate) fn generate_accessors<'a>(
-    indexed_fields: &'a [(Field, Ordering, Uniqueness)],
+    indexed_fields: &'a [(Field, Idents, Ordering, Uniqueness)],
     unindexed_fields: &'a [Field],
-    map_name: &'a proc_macro2::Ident,
     element_name: &'a proc_macro2::Ident,
     removes: &'a [proc_macro2::TokenStream],
     pre_modifies: &'a [proc_macro2::TokenStream],
     post_modifies: &'a [proc_macro2::TokenStream],
 ) -> impl Iterator<Item = proc_macro2::TokenStream> + 'a {
-    let unindexed_types = unindexed_fields
-        .iter()
-        .map(|f| {
-            let ty = &f.ty;
-            quote! {
-                #ty
-            }
-        })
-        .collect::<Vec<_>>();
-
+    let unindexed_types = unindexed_fields.iter().map(|f| &f.ty).collect::<Vec<_>>();
     let unindexed_idents = unindexed_fields
         .iter()
-        .map(|f| {
-            let ident = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
-            quote! {
-                #ident
-            }
-        })
+        .map(|f| f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS))
         .collect::<Vec<_>>();
 
-    indexed_fields.iter().map(move |(f, ordering, uniqueness)| {
-        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
-        let field_name_string = field_name.to_string();
+    indexed_fields.iter().map(move |(f, idents, ordering, uniqueness)| {
+        let field_ident = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
+        let field_ident_string = field_ident.to_string();
         let field_vis = &f.vis;
-        let index_name = format_ident!("_{field_name}_index");
-        let getter_name = format_ident!("get_by_{field_name}", );
-        let mut_getter_name = format_ident!("get_mut_by_{field_name}");
-        let remover_name = format_ident!("remove_by_{field_name}");
-        let modifier_name = format_ident!("modify_by_{field_name}");
-        let updater_name = format_ident!("update_by_{field_name}");
-        let iter_name = format_ident!(
-            "{map_name}{}Iter",
-            field_name.to_string().to_case(::convert_case::Case::UpperCamel)
-        );
-        let iter_getter_name = format_ident!("iter_by_{field_name}");
+        let index_ident = &idents.index;
+        let getter_name = format_ident!("get_by_{field_ident}", );
+        let mut_getter_name = format_ident!("get_mut_by_{field_ident}");
+        let remover_name = format_ident!("remove_by_{field_ident}");
+        let modifier_name = format_ident!("modify_by_{field_ident}");
+        let updater_name = format_ident!("update_by_{field_ident}");
+        let iter_name = &idents.iter;
+        let iter_getter_name = format_ident!("iter_by_{field_ident}");
         let ty = &f.ty;
 
         // TokenStream representing the get_by_ accessor for this field.
@@ -335,12 +313,12 @@ pub(crate) fn generate_accessors<'a>(
         let getter = match uniqueness {
             Uniqueness::Unique => quote! {
                 #field_vis fn #getter_name(&self, key: &#ty) -> Option<&#element_name> {
-                    Some(&self._store[*self.#index_name.get(key)?])
+                    Some(&self._store[*self.#index_ident.get(key)?])
                 }
             },
             Uniqueness::NonUnique => quote! {
                 #field_vis fn #getter_name(&self, key: &#ty) -> Vec<&#element_name> {
-                    if let Some(idxs) = self.#index_name.get(key) {
+                    if let Some(idxs) = self.#index_ident.get(key) {
                         let mut elem_refs = Vec::with_capacity(idxs.len());
                         for idx in idxs {
                             elem_refs.push(&self._store[*idx])
@@ -362,7 +340,7 @@ pub(crate) fn generate_accessors<'a>(
                 /// If the indexed fields need to be changed, the modify() method must be used.
                 #[deprecated(since="0.7.0", note="please use `update_by_` methods to update non-indexed fields instead, these are equally performant but are safe")]
                 #field_vis unsafe fn #mut_getter_name(&mut self, key: &#ty) -> Option<&mut #element_name> {
-                    Some(&mut self._store[*self.#index_name.get(key)?])
+                    Some(&mut self._store[*self.#index_ident.get(key)?])
                 }
             },
             Uniqueness::NonUnique => quote! {
@@ -372,7 +350,7 @@ pub(crate) fn generate_accessors<'a>(
                 /// If the indexed fields need to be changed, the modify() method must be used.
                 #[deprecated(since="0.7.0", note="please use `update_by_` methods to update non-indexed fields instead, these are equally performant but are safe")]
                 #field_vis unsafe fn #mut_getter_name(&mut self, key: &#ty) -> Vec<&mut #element_name> {
-                    if let Some(idxs) = self.#index_name.get(key) {
+                    if let Some(idxs) = self.#index_ident.get(key) {
                         let mut refs = Vec::with_capacity(idxs.len());
                         let mut mut_iter = self._store.iter_mut();
                         let mut last_idx: usize = 0;
@@ -384,7 +362,7 @@ pub(crate) fn generate_accessors<'a>(
                                 _ => {
                                     panic!(
                                         "Error getting mutable reference of non-unique field `{}` in getter.",
-                                        #field_name_string
+                                        #field_ident_string
                                     );
                                 }
                             }
@@ -409,7 +387,7 @@ pub(crate) fn generate_accessors<'a>(
             Uniqueness::Unique => quote! {
 
                 #field_vis fn #remover_name(&mut self, key: &#ty) -> Option<#element_name> {
-                    let idx = self.#index_name.remove(key)?;
+                    let idx = self.#index_ident.remove(key)?;
                     let elem_orig = self._store.remove(idx);
                     #(#removes)*
                     Some(elem_orig)
@@ -417,7 +395,7 @@ pub(crate) fn generate_accessors<'a>(
             },
             Uniqueness::NonUnique => quote! {
                 #field_vis fn #remover_name(&mut self, key: &#ty) -> Vec<#element_name> {
-                    if let Some(idxs) = self.#index_name.remove(key) {
+                    if let Some(idxs) = self.#index_ident.remove(key) {
                         let mut elems = Vec::with_capacity(idxs.len());
                         for idx in idxs {
                             let elem_orig = self._store.remove(idx);
@@ -439,7 +417,7 @@ pub(crate) fn generate_accessors<'a>(
                     key: &#ty,
                     f: impl FnOnce(#(&mut #unindexed_types,)*)
                 ) -> Option<&#element_name> {
-                    let idx = *self.#index_name.get(key)?;
+                    let idx = *self.#index_ident.get(key)?;
                     let elem = &mut self._store[idx];
                     f(#(&mut elem.#unindexed_idents,)*);
                     Some(elem)
@@ -452,7 +430,7 @@ pub(crate) fn generate_accessors<'a>(
                     mut f: impl FnMut(#(&mut #unindexed_types,)*)
                 ) -> Vec<&#element_name> {
                     let empty = ::std::collections::BTreeSet::<usize>::new();
-                    let idxs = match self.#index_name.get(key) {
+                    let idxs = match self.#index_ident.get(key) {
                         Some(container) => container,
                         _ => &empty,
                     };
@@ -470,7 +448,7 @@ pub(crate) fn generate_accessors<'a>(
                             _ => {
                                 panic!(
                                     "Error getting mutable reference of non-unique field `{}` in updater.",
-                                    #field_name_string
+                                    #field_ident_string
                                 );
                             }
                         }
@@ -493,7 +471,7 @@ pub(crate) fn generate_accessors<'a>(
                     key: &#ty,
                     f: impl FnOnce(&mut #element_name)
                 ) -> Option<&#element_name> {
-                    let idx = *self.#index_name.get(key)?;
+                    let idx = *self.#index_ident.get(key)?;
                     let elem = &mut self._store[idx];
                     #(#pre_modifies)*
                     f(elem);
@@ -507,7 +485,7 @@ pub(crate) fn generate_accessors<'a>(
                     key: &#ty,
                     f: impl Fn(&mut #element_name)
                 ) -> Vec<&#element_name> {
-                    let idxs = match self.#index_name.get(key) {
+                    let idxs = match self.#index_ident.get(key) {
                         Some(container) => container.clone(),
                         _ => ::std::collections::BTreeSet::<usize>::new()
                     };
@@ -526,7 +504,7 @@ pub(crate) fn generate_accessors<'a>(
                             _ => {
                                 panic!(
                                     "Error getting mutable reference of non-unique field `{}` in modifier.",
-                                    #field_name_string
+                                    #field_ident_string
                                 );
                             }
                         }
@@ -541,15 +519,15 @@ pub(crate) fn generate_accessors<'a>(
             Ordering::Hashed => quote! {
                 #iter_name {
                     _store_ref: &self._store,
-                    _iter: self.#index_name.iter(),
+                    _iter: self.#index_ident.iter(),
                     _inner_iter: None,
                 }
             },
             Ordering::Ordered => quote! {
                 #iter_name {
                     _store_ref: &self._store,
-                    _iter: self.#index_name.iter(),
-                    _iter_rev: self.#index_name.iter().rev(),
+                    _iter: self.#index_ident.iter(),
+                    _iter_rev: self.#index_ident.iter().rev(),
                     _inner_iter: None,
                 }
             },
@@ -579,21 +557,17 @@ pub(crate) fn generate_accessors<'a>(
 //   via that field,
 // such that the elements are accessed in an order defined by the index rather than the backing storage.
 pub(crate) fn generate_iterators<'a>(
-    fields: &'a [(Field, Ordering, Uniqueness)],
-    map_name: &'a proc_macro2::Ident,
+    fields: &'a [(Field, Idents, Ordering, Uniqueness)],
     element_name: &'a proc_macro2::Ident,
 ) -> impl Iterator<Item = proc_macro2::TokenStream> + 'a {
-    fields.iter().map(move |(f, ordering, uniqueness)| {
-        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
+    fields.iter().map(move |(f, idents, ordering, uniqueness)| {
+        let field_ident = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
         let field_vis = &f.vis;
-        let field_name_string = field_name.to_string();
+        let field_ident_string = field_ident.to_string();
         let error_msg = format!(
-            "Internal invariants broken, found empty slice in non_unique index '{field_name_string}'"
+            "Internal invariants broken, found empty slice in non_unique index '{field_ident_string}'"
         );
-        let iter_name = format_ident!(
-            "{map_name}{}Iter",
-            field_name.to_string().to_case(::convert_case::Case::UpperCamel)
-        );
+        let iter_name = &idents.iter;
         let ty = &f.ty;
 
         // TokenStream representing the actual type of the iterator

--- a/multi_index_map_derive/src/generators.rs
+++ b/multi_index_map_derive/src/generators.rs
@@ -2,17 +2,19 @@ use ::quote::{format_ident, quote};
 use ::syn::{Field, Visibility};
 use proc_macro2::Ident;
 use proc_macro_error::OptionExt;
+use syn::Type;
 
 use crate::index_attributes::{Ordering, Uniqueness};
 
-// Struct to store generated identifiers.
+// Struct to store generated identifiers for each field.
 // These are set once during the initial pass over the indexed fields,
 //   then reused in each generator, to reduce work done at compile-time,
 //   and to ensure each generator uses the same identifiers.
-pub(crate) struct Idents {
-    pub(crate) index: Ident,
-    pub(crate) orig: Ident,
-    pub(crate) iter: Ident,
+pub(crate) struct FieldIdents {
+    pub(crate) name: Ident,
+    pub(crate) index_name: Ident,
+    pub(crate) cloned_name: Ident,
+    pub(crate) iter_name: Ident,
 }
 
 pub(crate) const EXPECT_NAMED_FIELDS: &str =
@@ -22,11 +24,11 @@ pub(crate) const EXPECT_NAMED_FIELDS: &str =
 // Each lookup table maps it's index to a position in the backing storage,
 // or multiple positions in the backing storage in the non-unique indexes.
 pub(crate) fn generate_lookup_tables(
-    fields: &[(Field, Idents, Ordering, Uniqueness)],
+    fields: &[(Field, FieldIdents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
     fields.iter().map(|(f, idents, ordering, uniqueness)| {
         let ty = &f.ty;
-        let index_name = &idents.index;
+        let index_name = &idents.index_name;
 
         match uniqueness {
             Uniqueness::Unique => match ordering {
@@ -54,10 +56,10 @@ pub(crate) fn generate_lookup_tables(
 // If lookup table data structures support `with_capacity`, change `default()` and `new()` calls to
 //   `with_capacity(n)`
 pub(crate) fn generate_lookup_table_init(
-    fields: &[(Field, Idents, Ordering, Uniqueness)],
+    fields: &[(Field, FieldIdents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
     fields.iter().map(|(_f, idents, ordering, _uniqueness)| {
-        let index_name = &idents.index;
+        let index_name = &idents.index_name;
 
         match ordering {
             Ordering::Hashed => quote! {
@@ -75,10 +77,10 @@ pub(crate) fn generate_lookup_table_init(
 // Currently `BTreeMap::extend_reserve()` is nightly-only and uses the trait default implementation, which does nothing.
 // Once this is implemented and stabilized, we will use it here to reserve capacity.
 pub(crate) fn generate_lookup_table_reserve(
-    fields: &[(Field, Idents, Ordering, Uniqueness)],
+    fields: &[(Field, FieldIdents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
     fields.iter().map(|(_f, idents, ordering, _uniqueness)| {
-        let index_name = &idents.index;
+        let index_name = &idents.index_name;
 
         match ordering {
             Ordering::Hashed => quote! {
@@ -94,10 +96,10 @@ pub(crate) fn generate_lookup_table_reserve(
 // For consistency, HashMaps are shrunk to the capacity of the backing storage
 // `BTreeMap` does not support shrinking.
 pub(crate) fn generate_lookup_table_shrink(
-    fields: &[(Field, Idents, Ordering, Uniqueness)],
+    fields: &[(Field, FieldIdents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
     fields.iter().map(|(_f, idents, ordering, _uniqueness)| {
-        let index_name = &idents.index;
+        let index_name = &idents.index_name;
 
         match ordering {
             Ordering::Hashed => quote! {
@@ -114,12 +116,12 @@ pub(crate) fn generate_lookup_table_shrink(
 //   whereas non-unique fields require inserting to the container of positions,
 //   creating a new container if necessary.
 pub(crate) fn generate_inserts(
-    fields: &[(Field, Idents, Ordering, Uniqueness)],
+    fields: &[(Field, FieldIdents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
-    fields.iter().map(|(f, idents, _ordering, uniqueness)| {
-        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
+    fields.iter().map(|(_f, idents, _ordering, uniqueness)| {
+        let field_name = &idents.name;
         let field_name_string = stringify!(field_name);
-        let index_name = &idents.index;
+        let index_name = &idents.index_name;
 
         match uniqueness {
             Uniqueness::Unique => quote! {
@@ -154,12 +156,12 @@ pub(crate) fn generate_inserts(
 //     + If there are exactly one index in the container, then the index has to be idx,
 //       remove the key from the lookup table
 pub(crate) fn generate_removes(
-    fields: &[(Field, Idents, Ordering, Uniqueness)],
+    fields: &[(Field, FieldIdents, Ordering, Uniqueness)],
 ) -> Vec<::proc_macro2::TokenStream> {
     fields
         .iter()
-        .map(|(f, idents, _ordering, uniqueness)| {
-            let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
+        .map(|(_f, idents, _ordering, uniqueness)| {
+            let field_name = &idents.name;
             let field_name_string = stringify!(field_name);
             let error_msg = format!(
                 concat!(
@@ -168,7 +170,7 @@ pub(crate) fn generate_removes(
                 ),
                 field_name_string
             );
-            let index_name = &idents.index;
+            let index_name = &idents.index_name;
 
             match uniqueness {
                 Uniqueness::Unique => quote! {
@@ -195,13 +197,13 @@ pub(crate) fn generate_removes(
 // For each indexed field generate a TokenStream representing the clone the original value,
 //   so that we can compare after the modify is applied and adjust lookup tables as necessary
 pub(crate) fn generate_pre_modifies(
-    fields: &[(Field, Idents, Ordering, Uniqueness)],
+    fields: &[(Field, FieldIdents, Ordering, Uniqueness)],
 ) -> Vec<::proc_macro2::TokenStream> {
     fields
         .iter()
-        .map(|(field, idents, _, _)| {
-            let field_name = field.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
-            let orig_ident = &idents.orig;
+        .map(|(_f, idents, _, _)| {
+            let field_name = &idents.name;
+            let orig_ident = &idents.cloned_name;
 
             quote! {
                 let #orig_ident = elem.#field_name.clone();
@@ -223,13 +225,13 @@ pub(crate) fn generate_pre_modifies(
 //     + if the container is empty after removal, remove the old key, and insert idx to the new key
 //       (create a new container if necessary)
 pub(crate) fn generate_post_modifies(
-    fields: &[(Field, Idents, Ordering, Uniqueness)],
+    fields: &[(Field, FieldIdents, Ordering, Uniqueness)],
 ) -> Vec<::proc_macro2::TokenStream> {
-    fields.iter().map(|(f, idents, _ordering, uniqueness)| {
-        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
+    fields.iter().map(|(_f, idents, _ordering, uniqueness)| {
+        let field_name = &idents.name;
         let field_name_string = stringify!(field_name);
-        let orig_ident = &idents.orig;
-        let index_name = &idents.index;
+        let orig_ident = &idents.cloned_name;
+        let index_name = &idents.index_name;
         let error_msg = format!(
             concat!(
                 "Internal invariants broken, ",
@@ -271,10 +273,10 @@ pub(crate) fn generate_post_modifies(
 }
 
 pub(crate) fn generate_clears(
-    fields: &[(Field, Idents, Ordering, Uniqueness)],
+    fields: &[(Field, FieldIdents, Ordering, Uniqueness)],
 ) -> impl Iterator<Item = ::proc_macro2::TokenStream> + '_ {
     fields.iter().map(|(_f, idents, _ordering, _uniqueness)| {
-        let index_name = &idents.index;
+        let index_name = &idents.index_name;
 
         quote! {
             self.#index_name.clear();
@@ -282,10 +284,315 @@ pub(crate) fn generate_clears(
     })
 }
 
+// TokenStream representing the get_by_ accessor for this field.
+// For non-unique indexes we must go through all matching elements and find their positions,
+//   in order to return a Vec of references to the backing storage.
+fn generate_field_getter(
+    field_idents: &FieldIdents,
+    field_vis: &Visibility,
+    field_type: &Type,
+    element_name: &Ident,
+    uniqueness: &Uniqueness,
+) -> proc_macro2::TokenStream {
+    let getter_name = format_ident!("get_by_{}", &field_idents.name);
+    let index_name = &field_idents.index_name;
+
+    match uniqueness {
+        Uniqueness::Unique => quote! {
+            #field_vis fn #getter_name(&self, key: &#field_type) -> Option<&#element_name> {
+                Some(&self._store[*self.#index_name.get(key)?])
+            }
+        },
+        Uniqueness::NonUnique => quote! {
+            #field_vis fn #getter_name(&self, key: &#field_type) -> Vec<&#element_name> {
+                if let Some(idxs) = self.#index_name.get(key) {
+                    let mut elem_refs = Vec::with_capacity(idxs.len());
+                    for idx in idxs {
+                        elem_refs.push(&self._store[*idx])
+                    }
+                    elem_refs
+                } else {
+                    Vec::new()
+                }
+            }
+        },
+    }
+}
+
+// TokenStream representing the get_mut_by_ accessor for this field.
+// Note that these methods are deprecated, and will be removed in a future version.
+fn generate_field_mut_getter(
+    field_idents: &FieldIdents,
+    field_vis: &Visibility,
+    field_type: &Type,
+    field_name_string: &str,
+    element_name: &Ident,
+    uniqueness: &Uniqueness,
+) -> proc_macro2::TokenStream {
+    let mut_getter_name = format_ident!("get_mut_by_{}", &field_idents.name);
+    let index_name = &field_idents.index_name;
+
+    match uniqueness {
+        Uniqueness::Unique => quote! {
+            /// SAFETY:
+            /// It is safe to mutate the non-indexed fields,
+            /// however mutating any of the indexed fields will break the internal invariants.
+            /// If the indexed fields need to be changed, the modify() method must be used.
+            #[deprecated(since="0.7.0", note="please use `update_by_` methods to update non-indexed fields instead, these are equally performant but are safe")]
+            #field_vis unsafe fn #mut_getter_name(&mut self, key: &#field_type) -> Option<&mut #element_name> {
+                Some(&mut self._store[*self.#index_name.get(key)?])
+            }
+        },
+        Uniqueness::NonUnique => quote! {
+            /// SAFETY:
+            /// It is safe to mutate the non-indexed fields,
+            /// however mutating any of the indexed fields will break the internal invariants.
+            /// If the indexed fields need to be changed, the modify() method must be used.
+            #[deprecated(since="0.7.0", note="please use `update_by_` methods to update non-indexed fields instead, these are equally performant but are safe")]
+            #field_vis unsafe fn #mut_getter_name(&mut self, key: &#field_type) -> Vec<&mut #element_name> {
+                if let Some(idxs) = self.#index_name.get(key) {
+                    let mut refs = Vec::with_capacity(idxs.len());
+                    let mut mut_iter = self._store.iter_mut();
+                    let mut last_idx: usize = 0;
+                    for idx in idxs.iter() {
+                        match mut_iter.nth(*idx - last_idx) {
+                            Some(val) => {
+                                refs.push(val.1)
+                            },
+                            _ => {
+                                panic!(
+                                    "Error getting mutable reference of non-unique field `{}` in getter.",
+                                    #field_name_string
+                                );
+                            }
+                        }
+                        last_idx = *idx + 1;
+                    }
+                    refs
+                } else {
+                    Vec::new()
+                }
+            }
+        },
+    }
+}
+
+// TokenStream representing the remove_by_ accessor for this field.
+// For non-unique indexes we must go through all matching elements and find their positions,
+// in order to return a Vec elements from the backing storage.
+//      - get the back storage index(s)
+//      - mark the index(s) as unused in back storage
+//      - remove the index(s) from all fields
+//      - return the element(s)
+fn generate_field_remover(
+    field_idents: &FieldIdents,
+    field_vis: &Visibility,
+    field_type: &Type,
+    element_name: &Ident,
+    uniqueness: &Uniqueness,
+    removes: &[proc_macro2::TokenStream],
+) -> proc_macro2::TokenStream {
+    let remover_name = format_ident!("remove_by_{}", &field_idents.name);
+    let index_name = &field_idents.index_name;
+
+    match uniqueness {
+        Uniqueness::Unique => quote! {
+            #field_vis fn #remover_name(&mut self, key: &#field_type) -> Option<#element_name> {
+                let idx = self.#index_name.remove(key)?;
+                let elem_orig = self._store.remove(idx);
+                #(#removes)*
+                Some(elem_orig)
+            }
+        },
+        Uniqueness::NonUnique => quote! {
+            #field_vis fn #remover_name(&mut self, key: &#field_type) -> Vec<#element_name> {
+                if let Some(idxs) = self.#index_name.remove(key) {
+                    let mut elems = Vec::with_capacity(idxs.len());
+                    for idx in idxs {
+                        let elem_orig = self._store.remove(idx);
+                        #(#removes)*
+                        elems.push(elem_orig)
+                    }
+                    elems
+                } else {
+                    Vec::new()
+                }
+            }
+        },
+    }
+}
+
+fn generate_field_updater(
+    field_idents: &FieldIdents,
+    field_vis: &Visibility,
+    field_type: &Type,
+    field_name_string: &str,
+    element_name: &Ident,
+    uniqueness: &Uniqueness,
+    unindexed_types: &[&Type],
+    unindexed_idents: &[&Ident],
+) -> proc_macro2::TokenStream {
+    let updater_name = format_ident!("update_by_{}", &field_idents.name);
+    let index_name = &field_idents.index_name;
+
+    match uniqueness {
+        Uniqueness::Unique => quote! {
+            #field_vis fn #updater_name(
+                &mut self,
+                key: &#field_type,
+                f: impl FnOnce(#(&mut #unindexed_types,)*)
+            ) -> Option<&#element_name> {
+                let idx = *self.#index_name.get(key)?;
+                let elem = &mut self._store[idx];
+                f(#(&mut elem.#unindexed_idents,)*);
+                Some(elem)
+            }
+        },
+        Uniqueness::NonUnique => quote! {
+            #field_vis fn #updater_name(
+                &mut self,
+                key: &#field_type,
+                mut f: impl FnMut(#(&mut #unindexed_types,)*)
+            ) -> Vec<&#element_name> {
+                let empty = ::std::collections::BTreeSet::<usize>::new();
+                let idxs = match self.#index_name.get(key) {
+                    Some(container) => container,
+                    _ => &empty,
+                };
+
+                let mut refs = Vec::with_capacity(idxs.len());
+                let mut mut_iter = self._store.iter_mut();
+                let mut last_idx: usize = 0;
+                for idx in idxs {
+                    match mut_iter.nth(idx - last_idx) {
+                        Some(val) => {
+                            let elem = val.1;
+                            f(#(&mut elem.#unindexed_idents,)*);
+                            refs.push(&*elem);
+                        }
+                        _ => {
+                            panic!(
+                                "Error getting mutable reference of non-unique field `{}` in updater.",
+                                #field_name_string
+                            );
+                        }
+                    }
+                    last_idx = idx + 1;
+                }
+                refs
+            }
+        },
+    }
+}
+
+// TokenStream representing the modify_by_ accessor for this field.
+//      - obtain mutable reference (s) of the element
+//      - apply changes to the reference(s)
+//      - for each changed element, update all changed fields
+//      - return the modified item(s) as references
+fn generate_field_modifier(
+    field_idents: &FieldIdents,
+    field_vis: &Visibility,
+    field_type: &Type,
+    field_name_string: &str,
+    element_name: &Ident,
+    uniqueness: &Uniqueness,
+    pre_modifies: &[proc_macro2::TokenStream],
+    post_modifies: &[proc_macro2::TokenStream],
+) -> proc_macro2::TokenStream {
+    let modifier_name = format_ident!("modify_by_{}", &field_idents.name);
+    let index_name = &field_idents.index_name;
+
+    match uniqueness {
+        Uniqueness::Unique => quote! {
+            #field_vis fn #modifier_name(
+                &mut self,
+                key: &#field_type,
+                f: impl FnOnce(&mut #element_name)
+            ) -> Option<&#element_name> {
+                let idx = *self.#index_name.get(key)?;
+                let elem = &mut self._store[idx];
+                #(#pre_modifies)*
+                f(elem);
+                #(#post_modifies)*
+                Some(elem)
+            }
+        },
+        Uniqueness::NonUnique => quote! {
+            #field_vis fn #modifier_name(
+                &mut self,
+                key: &#field_type,
+                f: impl Fn(&mut #element_name)
+            ) -> Vec<&#element_name> {
+                let idxs = match self.#index_name.get(key) {
+                    Some(container) => container.clone(),
+                    _ => ::std::collections::BTreeSet::<usize>::new()
+                };
+                let mut refs = Vec::with_capacity(idxs.len());
+                let mut mut_iter = self._store.iter_mut();
+                let mut last_idx: usize = 0;
+                for idx in idxs {
+                    match mut_iter.nth(idx - last_idx) {
+                        Some(val) => {
+                            let elem = val.1;
+                            #(#pre_modifies)*
+                            f(elem);
+                            #(#post_modifies)*
+                            refs.push(&*elem);
+                        },
+                        _ => {
+                            panic!(
+                                "Error getting mutable reference of non-unique field `{}` in modifier.",
+                                #field_name_string
+                            );
+                        }
+                    }
+                    last_idx = idx + 1;
+                }
+                refs
+            }
+        },
+    }
+}
+
+fn generate_field_iter_getter(
+    field_idents: &FieldIdents,
+    field_vis: &Visibility,
+    ordering: &Ordering,
+) -> proc_macro2::TokenStream {
+    let iter_getter_name = format_ident!("iter_by_{}", &field_idents.name);
+    let iter_name = &field_idents.iter_name;
+    let index_name = &field_idents.index_name;
+
+    let iterator_def = match ordering {
+        Ordering::Hashed => quote! {
+            #iter_name {
+                _store_ref: &self._store,
+                _iter: self.#index_name.iter(),
+                _inner_iter: None,
+            }
+        },
+        Ordering::Ordered => quote! {
+            #iter_name {
+                _store_ref: &self._store,
+                _iter: self.#index_name.iter(),
+                _iter_rev: self.#index_name.iter().rev(),
+                _inner_iter: None,
+            }
+        },
+    };
+
+    quote! {
+        #field_vis fn #iter_getter_name(&self) -> #iter_name {
+            #iterator_def
+        }
+    }
+}
+
 // For each indexed field generate a TokenStream representing all the accessors
 //   for the underlying storage via that field's lookup table.
 pub(crate) fn generate_accessors<'a>(
-    indexed_fields: &'a [(Field, Idents, Ordering, Uniqueness)],
+    indexed_fields: &'a [(Field, FieldIdents, Ordering, Uniqueness)],
     unindexed_fields: &'a [Field],
     element_name: &'a proc_macro2::Ident,
     removes: &'a [proc_macro2::TokenStream],
@@ -298,281 +605,92 @@ pub(crate) fn generate_accessors<'a>(
         .map(|f| f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS))
         .collect::<Vec<_>>();
 
-    indexed_fields.iter().map(move |(f, idents, ordering, uniqueness)| {
-        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
-        let field_name_string = field_name.to_string();
-        let field_vis = &f.vis;
-        let index_name = &idents.index;
-        let getter_name = format_ident!("get_by_{field_name}", );
-        let mut_getter_name = format_ident!("get_mut_by_{field_name}");
-        let remover_name = format_ident!("remove_by_{field_name}");
-        let modifier_name = format_ident!("modify_by_{field_name}");
-        let updater_name = format_ident!("update_by_{field_name}");
-        let iter_name = &idents.iter;
-        let iter_getter_name = format_ident!("iter_by_{field_name}");
-        let ty = &f.ty;
+    indexed_fields
+        .iter()
+        .map(move |(f, idents, ordering, uniqueness)| {
+            let field_name = &idents.name;
+            let field_name_string = field_name.to_string();
+            let field_vis = &f.vis;
+            let field_type = &f.ty;
 
-        // TokenStream representing the get_by_ accessor for this field.
-        // For non-unique indexes we must go through all matching elements and find their positions,
-        // in order to return a Vec of references to the backing storage.
-        let getter = match uniqueness {
-            Uniqueness::Unique => quote! {
-                #field_vis fn #getter_name(&self, key: &#ty) -> Option<&#element_name> {
-                    Some(&self._store[*self.#index_name.get(key)?])
-                }
-            },
-            Uniqueness::NonUnique => quote! {
-                #field_vis fn #getter_name(&self, key: &#ty) -> Vec<&#element_name> {
-                    if let Some(idxs) = self.#index_name.get(key) {
-                        let mut elem_refs = Vec::with_capacity(idxs.len());
-                        for idx in idxs {
-                            elem_refs.push(&self._store[*idx])
-                        }
-                        elem_refs
-                    } else {
-                        Vec::new()
-                    }
-                }
-            },
-        };
+            let getter =
+                generate_field_getter(idents, field_vis, field_type, element_name, uniqueness);
 
-        // TokenStream representing the get_mut_by_ accessor for this field.
-        let mut_getter = match uniqueness {
-            Uniqueness::Unique => quote! {
-                /// SAFETY:
-                /// It is safe to mutate the non-indexed fields,
-                /// however mutating any of the indexed fields will break the internal invariants.
-                /// If the indexed fields need to be changed, the modify() method must be used.
-                #[deprecated(since="0.7.0", note="please use `update_by_` methods to update non-indexed fields instead, these are equally performant but are safe")]
-                #field_vis unsafe fn #mut_getter_name(&mut self, key: &#ty) -> Option<&mut #element_name> {
-                    Some(&mut self._store[*self.#index_name.get(key)?])
-                }
-            },
-            Uniqueness::NonUnique => quote! {
-                /// SAFETY:
-                /// It is safe to mutate the non-indexed fields,
-                /// however mutating any of the indexed fields will break the internal invariants.
-                /// If the indexed fields need to be changed, the modify() method must be used.
-                #[deprecated(since="0.7.0", note="please use `update_by_` methods to update non-indexed fields instead, these are equally performant but are safe")]
-                #field_vis unsafe fn #mut_getter_name(&mut self, key: &#ty) -> Vec<&mut #element_name> {
-                    if let Some(idxs) = self.#index_name.get(key) {
-                        let mut refs = Vec::with_capacity(idxs.len());
-                        let mut mut_iter = self._store.iter_mut();
-                        let mut last_idx: usize = 0;
-                        for idx in idxs.iter() {
-                            match mut_iter.nth(*idx - last_idx) {
-                                Some(val) => {
-                                    refs.push(val.1)
-                                },
-                                _ => {
-                                    panic!(
-                                        "Error getting mutable reference of non-unique field `{}` in getter.",
-                                        #field_name_string
-                                    );
-                                }
-                            }
-                            last_idx = *idx + 1;
-                        }
-                        refs
-                    } else {
-                        Vec::new()
-                    }
-                }
-            },
-        };
+            let mut_getter = generate_field_mut_getter(
+                idents,
+                field_vis,
+                field_type,
+                &field_name_string,
+                element_name,
+                uniqueness,
+            );
 
-        // TokenStream representing the remove_by_ accessor for this field.
-        // For non-unique indexes we must go through all matching elements and find their positions,
-        // in order to return a Vec elements from the backing storage.
-        //      - get the back storage index(s)
-        //      - mark the index(s) as unused in back storage
-        //      - remove the index(s) from all fields
-        //      - return the element(s)
-        let remover = match uniqueness {
-            Uniqueness::Unique => quote! {
+            let remover = generate_field_remover(
+                idents,
+                field_vis,
+                field_type,
+                element_name,
+                uniqueness,
+                removes,
+            );
 
-                #field_vis fn #remover_name(&mut self, key: &#ty) -> Option<#element_name> {
-                    let idx = self.#index_name.remove(key)?;
-                    let elem_orig = self._store.remove(idx);
-                    #(#removes)*
-                    Some(elem_orig)
-                }
-            },
-            Uniqueness::NonUnique => quote! {
-                #field_vis fn #remover_name(&mut self, key: &#ty) -> Vec<#element_name> {
-                    if let Some(idxs) = self.#index_name.remove(key) {
-                        let mut elems = Vec::with_capacity(idxs.len());
-                        for idx in idxs {
-                            let elem_orig = self._store.remove(idx);
-                            #(#removes)*
-                            elems.push(elem_orig)
-                        }
-                        elems
-                    } else {
-                        Vec::new()
-                    }
-                }
-            },
-        };
+            let updater = generate_field_updater(
+                idents,
+                field_vis,
+                field_type,
+                &field_name_string,
+                element_name,
+                uniqueness,
+                &unindexed_types,
+                &unindexed_idents,
+            );
 
-        let updater = match uniqueness {
-            Uniqueness::Unique => quote! {
-               #field_vis fn #updater_name(
-                    &mut self,
-                    key: &#ty,
-                    f: impl FnOnce(#(&mut #unindexed_types,)*)
-                ) -> Option<&#element_name> {
-                    let idx = *self.#index_name.get(key)?;
-                    let elem = &mut self._store[idx];
-                    f(#(&mut elem.#unindexed_idents,)*);
-                    Some(elem)
-               }
-            },
-            Uniqueness::NonUnique => quote! {
-                #field_vis fn #updater_name(
-                    &mut self,
-                    key: &#ty,
-                    mut f: impl FnMut(#(&mut #unindexed_types,)*)
-                ) -> Vec<&#element_name> {
-                    let empty = ::std::collections::BTreeSet::<usize>::new();
-                    let idxs = match self.#index_name.get(key) {
-                        Some(container) => container,
-                        _ => &empty,
-                    };
+            let modifier = generate_field_modifier(
+                idents,
+                field_vis,
+                field_type,
+                &field_name_string,
+                element_name,
+                uniqueness,
+                pre_modifies,
+                post_modifies,
+            );
 
-                    let mut refs = Vec::with_capacity(idxs.len());
-                    let mut mut_iter = self._store.iter_mut();
-                    let mut last_idx: usize = 0;
-                    for idx in idxs {
-                        match mut_iter.nth(idx - last_idx) {
-                            Some(val) => {
-                                let elem = val.1;
-                                f(#(&mut elem.#unindexed_idents,)*);
-                                refs.push(&*elem);
-                            }
-                            _ => {
-                                panic!(
-                                    "Error getting mutable reference of non-unique field `{}` in updater.",
-                                    #field_name_string
-                                );
-                            }
-                        }
-                        last_idx = idx + 1;
-                    }
-                    refs
-                }
+            let iter_getter = generate_field_iter_getter(idents, field_vis, ordering);
+
+            // Put all these TokenStreams together, and put a TokenStream representing the iter_by_ accessor
+            //   on the end.
+            quote! {
+                #getter
+
+                #mut_getter
+
+                #remover
+
+                #modifier
+
+                #updater
+
+                #iter_getter
             }
-        };
-
-        // TokenStream representing the modify_by_ accessor for this field.
-        //      - obtain mutable reference (s) of the element
-        //      - apply changes to the reference(s)
-        //      - for each changed element, update all changed fields
-        //      - return the modified item(s) as references
-        let modifier = match uniqueness {
-            Uniqueness::Unique => quote! {
-                #field_vis fn #modifier_name(
-                    &mut self,
-                    key: &#ty,
-                    f: impl FnOnce(&mut #element_name)
-                ) -> Option<&#element_name> {
-                    let idx = *self.#index_name.get(key)?;
-                    let elem = &mut self._store[idx];
-                    #(#pre_modifies)*
-                    f(elem);
-                    #(#post_modifies)*
-                    Some(elem)
-                }
-            },
-            Uniqueness::NonUnique => quote! {
-                #field_vis fn #modifier_name(
-                    &mut self,
-                    key: &#ty,
-                    f: impl Fn(&mut #element_name)
-                ) -> Vec<&#element_name> {
-                    let idxs = match self.#index_name.get(key) {
-                        Some(container) => container.clone(),
-                        _ => ::std::collections::BTreeSet::<usize>::new()
-                    };
-                    let mut refs = Vec::with_capacity(idxs.len());
-                    let mut mut_iter = self._store.iter_mut();
-                    let mut last_idx: usize = 0;
-                    for idx in idxs {
-                        match mut_iter.nth(idx - last_idx) {
-                            Some(val) => {
-                                let elem = val.1;
-                                #(#pre_modifies)*
-                                f(elem);
-                                #(#post_modifies)*
-                                refs.push(&*elem);
-                            },
-                            _ => {
-                                panic!(
-                                    "Error getting mutable reference of non-unique field `{}` in modifier.",
-                                    #field_name_string
-                                );
-                            }
-                        }
-                        last_idx = idx + 1;
-                    }
-                    refs
-                }
-            },
-        };
-
-        let iterator_def = match ordering {
-            Ordering::Hashed => quote! {
-                #iter_name {
-                    _store_ref: &self._store,
-                    _iter: self.#index_name.iter(),
-                    _inner_iter: None,
-                }
-            },
-            Ordering::Ordered => quote! {
-                #iter_name {
-                    _store_ref: &self._store,
-                    _iter: self.#index_name.iter(),
-                    _iter_rev: self.#index_name.iter().rev(),
-                    _inner_iter: None,
-                }
-            },
-        };
-
-        // Put all these TokenStreams together, and put a TokenStream representing the iter_by_ accessor
-        //   on the end.
-        quote! {
-            #getter
-
-            #mut_getter
-
-            #remover
-
-            #modifier
-
-            #updater
-
-            #field_vis fn #iter_getter_name(&self) -> #iter_name {
-                #iterator_def
-            }
-        }
-    })
+        })
 }
 
 // For each indexed field generate a TokenStream representing the Iterator over the backing storage
 //   via that field,
 // such that the elements are accessed in an order defined by the index rather than the backing storage.
 pub(crate) fn generate_iterators<'a>(
-    fields: &'a [(Field, Idents, Ordering, Uniqueness)],
+    fields: &'a [(Field, FieldIdents, Ordering, Uniqueness)],
     element_name: &'a proc_macro2::Ident,
 ) -> impl Iterator<Item = proc_macro2::TokenStream> + 'a {
     fields.iter().map(move |(f, idents, ordering, uniqueness)| {
-        let field_name = f.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
+        let field_name = &idents.name;
         let field_vis = &f.vis;
         let field_name_string = field_name.to_string();
         let error_msg = format!(
             "Internal invariants broken, found empty slice in non_unique index '{field_name_string}'"
         );
-        let iter_name = &idents.iter;
+        let iter_name = &idents.iter_name;
         let ty = &f.ty;
 
         // TokenStream representing the actual type of the iterator

--- a/multi_index_map_derive/src/lib.rs
+++ b/multi_index_map_derive/src/lib.rs
@@ -2,7 +2,7 @@ use ::proc_macro_error::{abort_call_site, proc_macro_error};
 use ::quote::format_ident;
 use ::syn::{parse_macro_input, DeriveInput};
 use convert_case::Casing;
-use generators::{Idents, EXPECT_NAMED_FIELDS};
+use generators::{FieldIdents, EXPECT_NAMED_FIELDS};
 use proc_macro_error::OptionExt;
 
 mod generators;
@@ -54,14 +54,15 @@ pub fn multi_index_map(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 
             let field_ident = field.ident.as_ref().expect_or_abort(EXPECT_NAMED_FIELDS);
 
-            let idents = Idents {
-                index: format_ident!("_{field_ident}_index",),
-                orig: format_ident!("{field_ident}_orig",),
-                iter: format_ident!(
+            let idents = FieldIdents {
+                name: field_ident.clone(),
+                index_name: format_ident!("_{field_ident}_index",),
+                cloned_name: format_ident!("{field_ident}_orig",),
+                iter_name: format_ident!(
                     "{map_name}{}Iter",
                     field_ident
                         .to_string()
-                        .to_case(::convert_case::Case::UpperCamel)
+                        .to_case(::convert_case::Case::UpperCamel),
                 ),
             };
 

--- a/multi_index_map_derive/src/lib.rs
+++ b/multi_index_map_derive/src/lib.rs
@@ -66,7 +66,9 @@ pub fn multi_index_map(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
 
     let removes = generators::generate_removes(&indexed_fields);
 
-    let modifies = generators::generate_modifies(&indexed_fields);
+    let pre_modifies = generators::generate_pre_modifies(&indexed_fields);
+
+    let post_modifies = generators::generate_post_modifies(&indexed_fields);
 
     let clears = generators::generate_clears(&indexed_fields);
 
@@ -80,7 +82,8 @@ pub fn multi_index_map(input: proc_macro::TokenStream) -> proc_macro::TokenStrea
         &map_name,
         element_name,
         &removes,
-        &modifies,
+        &pre_modifies,
+        &post_modifies,
     );
 
     let iterators = generators::generate_iterators(&indexed_fields, &map_name, element_name);


### PR DESCRIPTION
In this change all work necessary to remove Clone requirement has been implemented. However in order to fully remove the requirement I need to remove the derived Clone on the Map. This will be a breaking change (however it can be fixed by simply implementing Clone manually next to the Element), so I will split this change in two. First step will be a non-breaking change with all this refactoring, cleanup and optimisation, and the second will be breaking.