### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ fn main() {
     assert_eq!(order2_ref.order_id, 42);
     assert_eq!(order2_ref.trader_name, "JohnDoe".to_string());
 
-    let order2_ref = map.update_by_order_id(&42, |filled: &mut bool, volume: &mut u64| {
-        *filled = true;
-        *volume = 0;
-    })
-    .unwrap();
+    let order2_ref = map
+        .update_by_order_id(&42, |filled: &mut bool, volume: &mut u64| {
+            *filled = true;
+            *volume = 0;
+        })
+        .unwrap();
     assert_eq!(order2_ref.filled, true);
     assert_eq!(order2_ref.volume, 0);
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ fn main() {
     assert_eq!(order2_ref.order_id, 42);
     assert_eq!(order2_ref.trader_name, "JohnDoe".to_string());
 
-    let order2_ref = map.update_by_order_id(&2, |filled: &mut bool, volume: &mut u64| {
+    let order2_ref = map.update_by_order_id(&42, |filled: &mut bool, volume: &mut u64| {
         *filled = true;
         *volume = 0;
     });

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ fn main() {
     let order2_ref = map.update_by_order_id(&42, |filled: &mut bool, volume: &mut u64| {
         *filled = true;
         *volume = 0;
-    });
+    })
+    .unwrap();
     assert_eq!(order2_ref.filled, true);
     assert_eq!(order2_ref.volume, 0);
 


### PR DESCRIPTION
The example in the README currently does not compile. When fixing the compilation issue, the code crashes because the second order is not found with its initial id. This PR fixes these two minor issues.