### PR TITLE
Allow callers to use Borrowed key types, like stdlib collections

### DIFF
--- a/multi_index_map/tests/get_and_modify_mut.rs
+++ b/multi_index_map/tests/get_and_modify_mut.rs
@@ -1,8 +1,5 @@
 use multi_index_map::MultiIndexMap;
 
-#[derive(Hash, PartialEq, Eq, Clone)]
-struct TestNonPrimitiveType(u64);
-
 #[derive(MultiIndexMap, Clone, Debug)]
 #[multi_index_derive(Clone, Debug)]
 struct TestElement {

--- a/multi_index_map/tests/hashed_non_unique_with_string.rs
+++ b/multi_index_map/tests/hashed_non_unique_with_string.rs
@@ -69,3 +69,20 @@ fn iter_after_modify() {
         assert_eq!(it.next().unwrap().order_id, 4);
     }
 }
+
+#[test]
+fn get_by_borrowed_string() {
+    let o1 = Order {
+        order_id: 1,
+        timestamp: 111,
+        trader_name: "John".to_string(),
+    };
+
+    let mut map = MultiIndexOrderMap::default();
+
+    map.insert(o1);
+
+    let res = map.get_by_trader_name("John");
+    assert_eq!(res.len(), 1);
+    assert_eq!(res.first().unwrap().order_id, 1);
+}

--- a/multi_index_map/tests/hashed_unique.rs
+++ b/multi_index_map/tests/hashed_unique.rs
@@ -1,4 +1,4 @@
-use multi_index_map::{MultiIndexMap, UniquenessError};
+use multi_index_map::MultiIndexMap;
 
 #[derive(Hash, PartialEq, Eq, Clone)]
 struct TestNonPrimitiveType(u64);

--- a/multi_index_map/tests/update.rs
+++ b/multi_index_map/tests/update.rs
@@ -1,8 +1,5 @@
 use multi_index_map::MultiIndexMap;
 
-#[derive(Hash, PartialEq, Eq, Clone)]
-struct TestNonPrimitiveType(u64);
-
 #[derive(MultiIndexMap, PartialEq, Debug)]
 #[multi_index_derive(Debug)]
 struct TestElement {
@@ -12,6 +9,8 @@ struct TestElement {
     #[multi_index(hashed_unique)]
     field3: u32,
     field4: String,
+    #[multi_index(hashed_non_unique)]
+    field5: String,
 }
 
 #[test]
@@ -24,6 +23,7 @@ fn test_non_unique_update() {
                 field2: i as f64,
                 field3: i,
                 field4: i.to_string(),
+                field5: "42".to_string(),
             });
         } else {
             map.insert(TestElement {
@@ -31,11 +31,51 @@ fn test_non_unique_update() {
                 field2: i as f64,
                 field3: i,
                 field4: i.to_string(),
+                field5: "37".to_string(),
             });
         }
     }
 
     let refs = map.update_by_field1(&37, |field2, field4| {
+        *field2 = 99.0;
+        *field4 = "NinetyNine".to_string()
+    });
+    for r in refs.iter() {
+        assert_eq!(r.field2, 99.0);
+        assert_eq!(r.field4, "NinetyNine");
+    }
+
+    let refs = map.get_by_field1(&42);
+    for (i, r) in refs.iter().enumerate() {
+        assert_eq!(r.field2, i as f64 * 2.0);
+        assert_eq!(r.field4, (i * 2).to_string());
+    }
+}
+
+#[test]
+fn test_non_unique_update_borrow() {
+    let mut map = MultiIndexTestElementMap::default();
+    for i in 0..10 {
+        if i % 2 == 0 {
+            map.insert(TestElement {
+                field1: 42,
+                field2: i as f64,
+                field3: i,
+                field4: i.to_string(),
+                field5: "42".to_string(),
+            });
+        } else {
+            map.insert(TestElement {
+                field1: 37,
+                field2: i as f64,
+                field3: i,
+                field4: i.to_string(),
+                field5: "37".to_string(),
+            });
+        }
+    }
+
+    let refs = map.update_by_field5("37", |field2, field4| {
         *field2 = 99.0;
         *field4 = "NinetyNine".to_string()
     });
@@ -61,6 +101,7 @@ fn test_unique_update() {
                 field2: i as f64,
                 field3: i,
                 field4: i.to_string(),
+                field5: "42".to_string(),
             });
         } else {
             map.insert(TestElement {
@@ -68,6 +109,7 @@ fn test_unique_update() {
                 field2: i as f64,
                 field3: i,
                 field4: i.to_string(),
+                field5: "37".to_string(),
             });
         }
     }
@@ -83,7 +125,8 @@ fn test_unique_update() {
             field1: 42,
             field2: 99.0,
             field3: 0,
-            field4: "NinetyNine".to_string()
+            field4: "NinetyNine".to_string(),
+            field5: "42".to_string()
         })
     );
 
@@ -95,7 +138,8 @@ fn test_unique_update() {
             field1: 37,
             field2: 1.0,
             field3: 1,
-            field4: 1.to_string()
+            field4: 1.to_string(),
+            field5: "37".to_string()
         })
     );
 }


### PR DESCRIPTION
Previously we only accepted references to the field type as keys. This works great when the field type is basic, eg. for u32, the lookup key will always be &u32. However when the field type is more complex, eg. String, it would be preferable to accept either &String or &str as a lookup key type.

I've changed the get_by_ and update_by_ methods to take a generic std::borrow::Borrow key, which solves this. For modify_by_ and remove_by_ methods, this is slightly more complicated due to limitations with generics. So these have been left for a future PR.