### PR TITLE
fix: use maintained fork of proc-macro-error

### DIFF
--- a/multi_index_map_derive/Cargo.toml
+++ b/multi_index_map_derive/Cargo.toml
@@ -24,7 +24,7 @@ quote = { version = "1.0" }
 proc-macro2 = { version = "1.0" }
 
 # Better error handling in proc macros, avoids using panic!
-proc-macro-error = { version = "1.0" }
+proc-macro-error2 = { version = "2.0" }
 
 # Used to convert the field names into UpperCamelCase for the Iterator names, and to snake_case for the module namespace.
 convert_case = { version = "0.6" }

--- a/multi_index_map_derive/src/generators.rs
+++ b/multi_index_map_derive/src/generators.rs
@@ -1,7 +1,7 @@
 use ::quote::{format_ident, quote};
 use ::syn::{Field, Visibility};
 use proc_macro2::Ident;
-use proc_macro_error::OptionExt;
+use proc_macro_error2::OptionExt;
 use syn::Type;
 
 use crate::index_attributes::{ExtraAttributes, Ordering, Uniqueness};

--- a/multi_index_map_derive/src/index_attributes.rs
+++ b/multi_index_map_derive/src/index_attributes.rs
@@ -1,6 +1,6 @@
 use ::syn::Field;
 use proc_macro2::Span;
-use proc_macro_error::emit_error;
+use proc_macro_error2::emit_error;
 use syn::{
     punctuated::Punctuated, spanned::Spanned, DeriveInput, Meta, MetaList, NestedMeta, Path,
 };

--- a/multi_index_map_derive/src/lib.rs
+++ b/multi_index_map_derive/src/lib.rs
@@ -1,9 +1,9 @@
-use ::proc_macro_error::{abort_call_site, proc_macro_error};
+use ::proc_macro_error2::{abort_call_site, proc_macro_error};
 use ::quote::format_ident;
 use ::syn::{parse_macro_input, DeriveInput};
 use convert_case::Casing;
 use generators::{FieldIdents, EXPECT_NAMED_FIELDS};
-use proc_macro_error::OptionExt;
+use proc_macro_error2::OptionExt;
 
 mod generators;
 mod index_attributes;


### PR DESCRIPTION
proc-macro-error is unmaintained, according to RUSTSEC-2024-0370.

see https://rustsec.org/advisories/RUSTSEC-2024-0370.html

Fortunately, proc-macro-error2 is a maintained fork.